### PR TITLE
deposit wallet init

### DIFF
--- a/src/depositWallet.ts
+++ b/src/depositWallet.ts
@@ -1,0 +1,18 @@
+import { type Address, getCreate2Address, type Hex, pad } from "viem";
+
+// TODO: replace with keccak256 of ERC1967 proxy init bytecode from deployed DepositWalletFactory
+const DEPOSIT_WALLET_INIT_CODE_HASH: Hex =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+/**
+ * Calculates the address of a given owner's deposit wallet.
+ * walletId = pad(ownerAddress, 32), used as CREATE2 salt.
+ * @param factory - address of the DepositWalletFactory contract
+ * @param owner - address of the wallet owner
+ */
+export const getDepositWalletAddress = (factory: Address, owner: Address): Address =>
+    getCreate2Address({
+        from: factory,
+        salt: pad(owner, { size: 32 }),
+        bytecodeHash: DEPOSIT_WALLET_INIT_CODE_HASH,
+    });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./debt/index.js";
 export * from "./markets/index.js";
 export * from "./matic/index.js";
 export { negRiskOperations } from "./negRisk/index.js";
+export { getDepositWalletAddress } from "./depositWallet.js";
 export { getProxyWalletAddress } from "./proxyWallet.js";
 export * from "./types.js";
 export { erc20TransferTransaction, ethTransferTransaction, getIndexSet, getMarketIndex } from "./utils/index.js";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new public helper for computing deposit wallet addresses, but it currently uses an all-zero init code hash placeholder which could yield incorrect addresses if used before being updated to the real deployed bytecode hash.
> 
> **Overview**
> Adds `getDepositWalletAddress` to deterministically compute a user's deposit wallet address via `CREATE2` using the factory address and a salt derived from the padded owner address.
> 
> Exports this helper from `src/index.ts` so it becomes part of the library’s public API; the computation currently relies on a placeholder `DEPOSIT_WALLET_INIT_CODE_HASH` that must be replaced with the real init code hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4f56806eeb99c40818781f1222408541908a1c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->